### PR TITLE
Create Containerfile.operator files in preparation to move to RHTAP

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -1,0 +1,53 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_8_1.20 AS builder
+
+WORKDIR /workspace
+# Copy the jsonnet source
+COPY . operator/
+COPY ./jsonnet/vendor/stolo-configuration/components/ components/
+
+# Build
+ADD https://github.com/stolostron/locutus/archive/935e4a75faa0bc840b9ef836a56789c3bb9eba2a.tar.gz /workspace/operator/locutus.tar.gz
+WORKDIR /workspace/operator/locutus
+RUN tar -xf /workspace/operator/locutus.tar.gz -C . --strip-components=1
+RUN GO111MODULE="on" CGO_ENABLED=1 go build
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+WORKDIR /
+COPY --from=builder /workspace/operator/locutus/locutus /locutus
+COPY --from=builder /workspace/operator/jsonnet /
+COPY --from=builder /workspace/components/ /components/
+COPY --from=builder /workspace/operator/jsonnet/vendor/ /vendor/
+
+RUN chgrp -R 0 /vendor && chmod -R g=u /vendor
+RUN chgrp -R 0 /components && chmod -R g=u /components
+
+ARG BUILD_DATE
+ARG VERSION
+ARG VCS_REF
+ARG DOCKERFILE_PATH
+ARG VCS_BRANCH
+
+LABEL vendor="Observatorium" \
+    name="observatorium/operator" \
+    description="Observatorium Operator" \
+    io.k8s.display-name="observatorium/operator" \
+    io.k8s.description="Observatorium Operator" \
+    maintainer="Observatorium <team-monitoring@redhat.com>" \
+    version="$VERSION" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.description="Observatorium Operator" \
+    org.label-schema.docker.cmd="docker run --rm observatorium/operator" \
+    org.label-schema.docker.dockerfile=$DOCKERFILE_PATH \
+    org.label-schema.name="observatorium/operator" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vcs-branch=$VCS_BRANCH \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/observatorium/operator" \
+    org.label-schema.vendor="observatorium/operator" \
+    org.label-schema.version=$VERSION
+
+ENTRYPOINT ["/locutus", "--renderer=jsonnet", "--renderer.jsonnet.entrypoint=main.jsonnet", "--trigger=resource", "--trigger.resource.config=config.yaml"]


### PR DESCRIPTION
Required by [ACM-7181](https://issues.redhat.com/browse/ACM-7181)

change builder image to: brew.registry.redhat.io//rh-osbs/openshift-golang-builder:rhel_8_1.20