### PR TITLE
[ACM-8543] Label Observatorium API pods with the Observatorium CR hash

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -471,6 +471,11 @@ local operatorObs = obs {
       if (v.kind == 'Deployment' &&
           std.startsWith(v.metadata.name, cr.metadata.name + '-observatorium-api')) then {
         template+: {
+          metadata+: {
+            labels+: {
+              'cr-hash': std.toString(std.md5(std.toString(cr.spec))),
+            },
+          },
           spec+: {
             containers: [
               if x.name == 'observatorium-api'

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -473,7 +473,7 @@ local operatorObs = obs {
         template+: {
           metadata+: {
             labels+: {
-              'cr-hash': std.toString(std.md5(std.toString(cr.spec))),
+              'cr-hash': std.toString(std.md5(std.toString(cr))),
             },
           },
           spec+: {


### PR DESCRIPTION
This should help trigger restarts on the Observatorium API Deployment whenever the Observatorium CR gets updated with different configuration or labels.

This is the 1st step of the complete solution, as this operator doesn't have any access to resources already created in the cluster, like ConfigMaps and Secrets. 

The 2nd step will be for the MCO operator to label the Observatorium CR itself with the hash of all the configuration files and secrets it's using. This will allows direct changes to these files that aren't a consequences of the CR changing to trigger a recreation of the pods.