### PR TITLE
Add security context to all workloads

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -508,6 +508,25 @@ local operatorObs = obs {
           },
         },
       } else {}
+    ) + (
+      if (
+        v.kind == 'StatefulSet' ||
+        v.kind == 'Deployment'
+        ) then {
+        template+: {
+          spec+: {
+            containers: [
+            c {
+              securityContext+: {
+                readOnlyRootFilesystem: true,
+                privileged: false
+              }
+            }
+            for c in super.containers
+            ],
+          },
+        },
+      } else {}
     ),
   }, operatorObs.manifests),
 }


### PR DESCRIPTION
This commit sets the following security context of all workloads directly handled by the operator:

```
securityContext:
    privileged: false
    readOnlyRootFilesystem: true
```

this as required by: RHOBS-1001