### PR TITLE
[ACM-9572] Proper building of Locutus to be friendly with container layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ WORKDIR /workspace
 COPY . operator/
 COPY ./jsonnet/vendor/stolo-configuration/components/ components/
 
+ARG LOCUTUS_GIT_REPO
+ARG LOCUTUS_GIT_REF
+
 # Build
-WORKDIR /workspace/operator
-RUN git clone https://github.com/stolostron/locutus --branch release-2.8
-RUN cd locutus; GO111MODULE="on" CGO_ENABLED=1 go build
+WORKDIR /workspace/operator/locutus
+ADD --keep-git-dir=true "$LOCUTUS_GIT_REPO#$LOCUTUS_GIT_REF" .
+RUN GO111MODULE="on" CGO_ENABLED=1 go build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
@@ -27,6 +30,9 @@ ARG VERSION
 ARG VCS_REF
 ARG DOCKERFILE_PATH
 ARG VCS_BRANCH
+ARG LOCUTUS_GIT_REPO
+ARG LOCUTUS_GIT_REF
+ARG LOCUTUS_GIT_TAG
 
 LABEL vendor="Observatorium" \
     name="observatorium/operator" \
@@ -44,6 +50,8 @@ LABEL vendor="Observatorium" \
     org.label-schema.vcs-branch=$VCS_BRANCH \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/observatorium/operator" \
+    org.label-schema.locutus.vcs-ref=$LOCUTUS_GIT_REF \
+    org.label-schema.locutus.vcs-branch=$LOCUTUS_GIT_TAG \
     org.label-schema.vendor="observatorium/operator" \
     org.label-schema.version=$VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,6 @@ WORKDIR /workspace
 COPY . operator/
 COPY ./jsonnet/vendor/stolo-configuration/components/ components/
 
-ARG LOCUTUS_GIT_REPO
-ARG LOCUTUS_GIT_REF
-
 # Build
 ADD https://github.com/stolostron/locutus/archive/935e4a75faa0bc840b9ef836a56789c3bb9eba2a.tar.gz /workspace/operator/locutus.tar.gz
 WORKDIR /workspace/operator/locutus
@@ -31,9 +28,6 @@ ARG VERSION
 ARG VCS_REF
 ARG DOCKERFILE_PATH
 ARG VCS_BRANCH
-ARG LOCUTUS_GIT_REPO
-ARG LOCUTUS_GIT_REF
-ARG LOCUTUS_GIT_TAG
 
 LABEL vendor="Observatorium" \
     name="observatorium/operator" \
@@ -51,8 +45,6 @@ LABEL vendor="Observatorium" \
     org.label-schema.vcs-branch=$VCS_BRANCH \
     org.label-schema.vcs-ref=$VCS_REF \
     org.label-schema.vcs-url="https://github.com/observatorium/operator" \
-    org.label-schema.locutus.vcs-ref=$LOCUTUS_GIT_REF \
-    org.label-schema.locutus.vcs-branch=$LOCUTUS_GIT_TAG \
     org.label-schema.vendor="observatorium/operator" \
     org.label-schema.version=$VERSION
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ARG LOCUTUS_GIT_REPO
 ARG LOCUTUS_GIT_REF
 
 # Build
+ADD "$LOCUTUS_GIT_REPO/archive/$LOCUTUS_GIT_REF.tar.gz" /workspace/operator/locutus.tar.gz
 WORKDIR /workspace/operator/locutus
-ADD --keep-git-dir=true "$LOCUTUS_GIT_REPO#$LOCUTUS_GIT_REF" .
+RUN tar -xf /workspace/operator/locutus.tar.gz -C . --strip-components=1
 RUN GO111MODULE="on" CGO_ENABLED=1 go build
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG LOCUTUS_GIT_REPO
 ARG LOCUTUS_GIT_REF
 
 # Build
-ADD "$LOCUTUS_GIT_REPO/archive/$LOCUTUS_GIT_REF.tar.gz" /workspace/operator/locutus.tar.gz
+ADD https://github.com/stolostron/locutus/archive/935e4a75faa0bc840b9ef836a56789c3bb9eba2a.tar.gz /workspace/operator/locutus.tar.gz
 WORKDIR /workspace/operator/locutus
 RUN tar -xf /workspace/operator/locutus.tar.gz -C . --strip-components=1
 RUN GO111MODULE="on" CGO_ENABLED=1 go build

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,11 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%d")
 BUILD_TIMESTAMP := $(shell date -u +"%Y-%m-%dT%H:%M:%S%Z")
 VCS_BRANCH := $(strip $(shell git rev-parse --abbrev-ref HEAD))
 VCS_REF := $(strip $(shell [ -d .git ] && git rev-parse --short HEAD))
-DOCKER_REPO ?= quay.io/observatorium/observatorium-operator
+DOCKER_REPO ?= quay.io/douglascamata/observatorium-operator
+
+LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus.git
+LOCUTUS_GIT_TAG :=  release-2.8
+LOCUTUS_GIT_REF :=
 
 BIN_DIR ?= $(shell pwd)/tmp/bin
 CONTROLLER_GEN ?= $(BIN_DIR)/controller-gen
@@ -41,6 +45,9 @@ container-build:
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
 		--build-arg DOCKERFILE_PATH="/Dockerfile" \
+		--build-arg LOCUTUS_GIT_REPO="$(LOCUTUS_GIT_REPO)" \
+		--build-arg LOCUTUS_GIT_TAG="$(LOCUTUS_GIT_TAG)" \
+		--build-arg LOCUTUS_GIT_REF="$(shell git ls-remote $(LOCUTUS_GIT_REPO) $(LOCUTUS_GIT_TAG) | cut -f1)" \
 		-t $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) .
 
 # Push the image

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ DOCKER_REPO ?= quay.io/observatorium/observatorium-operator
 
 LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus.git
 LOCUTUS_GIT_TAG :=  release-2.8
-LOCUTUS_GIT_REF :=
 
 BIN_DIR ?= $(shell pwd)/tmp/bin
 CONTROLLER_GEN ?= $(BIN_DIR)/controller-gen

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VCS_BRANCH := $(strip $(shell git rev-parse --abbrev-ref HEAD))
 VCS_REF := $(strip $(shell [ -d .git ] && git rev-parse --short HEAD))
 DOCKER_REPO ?= quay.io/observatorium/observatorium-operator
 
-LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus.git
+LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus
 LOCUTUS_GIT_TAG :=  release-2.8
 
 BIN_DIR ?= $(shell pwd)/tmp/bin

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BUILD_DATE := $(shell date -u +"%Y-%m-%d")
 BUILD_TIMESTAMP := $(shell date -u +"%Y-%m-%dT%H:%M:%S%Z")
 VCS_BRANCH := $(strip $(shell git rev-parse --abbrev-ref HEAD))
 VCS_REF := $(strip $(shell [ -d .git ] && git rev-parse --short HEAD))
-DOCKER_REPO ?= quay.io/douglascamata/observatorium-operator
+DOCKER_REPO ?= quay.io/observatorium/observatorium-operator
 
 LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus.git
 LOCUTUS_GIT_TAG :=  release-2.8

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ VCS_BRANCH := $(strip $(shell git rev-parse --abbrev-ref HEAD))
 VCS_REF := $(strip $(shell [ -d .git ] && git rev-parse --short HEAD))
 DOCKER_REPO ?= quay.io/observatorium/observatorium-operator
 
-LOCUTUS_GIT_REPO :=  https://github.com/stolostron/locutus
-LOCUTUS_GIT_TAG :=  release-2.8
-
 BIN_DIR ?= $(shell pwd)/tmp/bin
 CONTROLLER_GEN ?= $(BIN_DIR)/controller-gen
 
@@ -44,9 +41,6 @@ container-build:
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg VCS_BRANCH="$(VCS_BRANCH)" \
 		--build-arg DOCKERFILE_PATH="/Dockerfile" \
-		--build-arg LOCUTUS_GIT_REPO="$(LOCUTUS_GIT_REPO)" \
-		--build-arg LOCUTUS_GIT_TAG="$(LOCUTUS_GIT_TAG)" \
-		--build-arg LOCUTUS_GIT_REF="$(shell git ls-remote $(LOCUTUS_GIT_REPO) $(LOCUTUS_GIT_TAG) | cut -f1)" \
 		-t $(DOCKER_REPO):$(VCS_BRANCH)-$(BUILD_DATE)-$(VERSION) .
 
 # Push the image


### PR DESCRIPTION
* Safe for layer caching during the container build process.
* ~Adds a label with the Locutus git commit ref and tag.~
  * Had to remove this because of the way images are built by the CI/CD pipelines.