### PR TITLE
ACM-14578: Adding supported TLS ciphers to exported TLS struct for config that is imported later into Observability Operator.

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -318,6 +318,8 @@ type TLS struct {
 	ServerName string `json:"serverName,omitempty"`
 	// +optional
 	ReloadInterval string `json:"reloadInterval,omitempty"`
+	// +optional
+	CipherSuite string `json:"cipherSuite,omitempty"`
 }
 
 // EndpointsConfig contains the configuration for all endpoints


### PR DESCRIPTION
After lots of testing - I realised that the observatorium-api config is generated in the obs-operator and overwrites the default main.jsonnet that we supply here. 🙄  Adding the type here so it can be imported into multicluster-observability-operator.