### PR TITLE
Remove auto-approve and Tekton settings from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,12 +4,4 @@
     "updatePinnedDependencies": false
   }
   "lockFileMaintenance": false,
-  "autoApprove": true,
-  "tekton": {
-    "automerge": true,
-    "automergeStrategy": "rebase",
-    "automergeType": "pr",
-    "enabled": true,
-    "platformAutomerge": true
-  }
 }


### PR DESCRIPTION
Removed auto-approval and Tekton automerge settings from Renovate configuration.