### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for observatorium-operator-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -29,9 +29,10 @@ ARG VCS_REF
 ARG DOCKERFILE_PATH
 ARG VCS_BRANCH
 
-LABEL name="observatorium/operator" \
+LABEL name="rhacm2/observatorium-rhel9-operator" \
     summary="observatorium-operator" \
     com.redhat.component="observatorium-operator" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     description="Observatorium Operator" \
     io.openshift.tags="observability" \
     io.k8s.display-name="observatorium/operator" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
