### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,66 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+# Copy the jsonnet source
+COPY . operator/
+COPY ./jsonnet/vendor/stolo-configuration/components/ components/
+
+# Build
+WORKDIR /workspace/operator/locutus
+RUN GO111MODULE="on" CGO_ENABLED=1 GOFLAGS="" GOEXPERIMENT=strictfipsruntime go build
+
+# Remove test manifests containing TLS certificates/secrets from vendor directory
+RUN rm -rf /workspace/operator/jsonnet/vendor/github.com/observatorium/observatorium/configuration/tests \
+           /workspace/operator/jsonnet/vendor/github.com/stolostron/observatorium-deployment/configuration/tests
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+WORKDIR /
+COPY --from=builder /workspace/operator/locutus/locutus /locutus
+COPY --from=builder /workspace/operator/jsonnet /
+COPY --from=builder /workspace/components/ /components/
+COPY --from=builder /workspace/operator/jsonnet/vendor/ /vendor/
+
+RUN chgrp -R 0 /vendor && chmod -R g=u /vendor
+RUN chgrp -R 0 /components && chmod -R g=u /components
+
+ARG BUILD_DATE
+ARG VCS_REF
+ARG DOCKERFILE_PATH
+ARG VCS_BRANCH
+ARG IMAGE_VERSION
+ARG IMAGE_RELEASE
+
+LABEL name="rhacm2/observatorium-rhel9-operator" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    summary="observatorium-operator" \
+    vendor="Red Hat, Inc." \
+    release="$IMAGE_RELEASE" \
+    com.redhat.component="observatorium-operator" \
+    description="Observatorium Operator" \
+    io.openshift.tags="observability" \
+    io.k8s.display-name="observatorium/operator" \
+    io.k8s.description="Observatorium Operator" \
+    maintainer="Observatorium <team-monitoring@redhat.com>" \
+    version="$IMAGE_VERSION" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.description="Observatorium Operator" \
+    org.label-schema.docker.cmd="docker run --rm observatorium/operator" \
+    org.label-schema.docker.dockerfile=$DOCKERFILE_PATH \
+    org.label-schema.name="observatorium/operator" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vcs-branch=$VCS_BRANCH \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/observatorium/operator" \
+    org.label-schema.vendor="Red Hat, Inc." \
+    org.label-schema.version=$IMAGE_VERSION
+
+RUN mkdir -p /licenses
+COPY --from=builder /workspace/operator/LICENSE /licenses/
+
+USER 1001:1001
+
+ENTRYPOINT ["/locutus", "--renderer=jsonnet", "--renderer.jsonnet.entrypoint=main.jsonnet", "--trigger=resource", "--trigger.resource.config=config.yaml"]


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)