### PR TITLE
ACM-34943: Add Support For Merging/Overriding Default Thanos Compact Arguments

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -4,6 +4,24 @@ local loki = (import 'github.com/observatorium/observatorium/configuration/compo
 local api = (import 'lib/observatorium-api.libsonnet');
 local obs = (import 'stolo-configuration/components/observatorium.libsonnet');
 
+local argKey(arg) = std.splitLimit(arg, '=', 2)[0];
+local merge_args(base, overrides) =
+// Return only the base if the list of override args/args from CR is empty
+  if std.length(overrides) == 0 then base else
+  // Creates a map that has {"--a" : "--a=2} for example based on the args from CR
+  local overrideMap = { [argKey(arg)]: arg for arg in overrides };
+  // // Creates a map that has {"--b : "true"} for example based on args from the base/kube-thanos
+  local baseKeys = { [argKey(arg)]: true for arg in base };
+  [
+    // For each argument in the base, if the override map has that argument, then that argument and its value is added to a list
+    // Else the base value argument and its value is added instead
+    if std.objectHas(overrideMap, argKey(arg)) then overrideMap[argKey(arg)] else arg
+    for arg in base
+  ] + [
+    // Then for each argument in override if it is not in the base, add its argument 
+    arg for arg in overrides
+    if !std.objectHas(baseKeys, argKey(arg))
+  ];
 local override_containers(org_containers, custom_containers) =
   [
     if (c.name == custom_container.name) then c {
@@ -538,7 +556,7 @@ local operatorObs = obs {
           spec+: {
             containers: [
               if c.name == 'thanos-compact' then c {
-                args+: cr.spec.thanos.compact.args,
+                args: merge_args(c.args,cr.spec.thanos.compact.args)
               } else c
               for c in super.containers
             ],


### PR DESCRIPTION
Summary:

Fixes [ACM-34943](https://redhat.atlassian.net/browse/ACM-34943)

Problem:

When working on https://github.com/stolostron/multicluster-observability-operator/pull/2494, I noticed that when the Observatorium Operator had arguments passed to it that overrode the default arguments for Thanos Compact, it would append these arguments to the args list. This caused Thanos Compact pods to not start, as Thanos does not support having multiple instances of the same argument. 

Root Cause:
The root cause is the Observatorium Operator appending all additional arguments to the args list rather than overriding when needed.

Fix:

Add function to merge/override one array of arguments into another and use this function in Thanos Compact args generation

Files Changed:

Modified:
`obs-operator.jsonnet`

Test Plan:
Tested end to end on the collective cluster and verified that when the MCO CR sets fields that pass additional arguments to the Observatorium CRD, the Observatorium Operator correctly parses them and the Thanos compact pod successfully starts as intended. 

[ACM-34943]: https://redhat.atlassian.net/browse/ACM-34943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ