### PR TITLE
First pass of adding merge_args support to thanos recieve

### DIFF
--- a/api/v1alpha1/observatorium_types.go
+++ b/api/v1alpha1/observatorium_types.go
@@ -152,6 +152,9 @@ type ReceiversSpec struct {
 	// ServiceMonitor enables servicemonitor.
 	// +optional
 	ServiceMonitor bool `json:"serviceMonitor,omitempty"`
+	// LogLevel sets the log verbosity for the Thanos Receive component.
+	// +optional
+	LogLevel string `json:"logLevel,omitempty"`
 	// How long to retain raw samples on local storage
 	// +optional
 	Retention string `json:"retention,omitempty"`

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -46,7 +46,7 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "release-2.5"
+      "version": "97358548e62dc223fc678a3c3ac74339c2253780"
     }
   ],
   "legacyImports": true

--- a/jsonnet/jsonnetfile.lock.json
+++ b/jsonnet/jsonnetfile.lock.json
@@ -235,8 +235,8 @@
           "subdir": "configuration"
         }
       },
-      "version": "0d7102af5812fb3a3860fa24da9abbecdd0791f1",
-      "sum": "scQRMQLigajRyX7F6E9vvQQmmOUtd9VYBo+sRknllhs=",
+      "version": "8c14b6cd017f41572076decaaabda4b184aed84f",
+      "sum": "AiHePOoxo8tNCcZuLd2WYcC1u/b5SUomVRDNfIyrpMU=",
       "name": "stolo-configuration"
     },
     {
@@ -246,8 +246,8 @@
           "subdir": "jsonnet/lib"
         }
       },
-      "version": "2df9e7bc65394014cc7a1b61f37e0f8837f9ac91",
-      "sum": "axYSi0irj4BhHKYqQ9U575vNaX1Xo8IapJ/BpQUuzQI="
+      "version": "97358548e62dc223fc678a3c3ac74339c2253780",
+      "sum": "KaCTJO94cdpQDbu4HYfCZBOm8J4hnRonuuqtiOa4wtY="
     },
     {
       "source": {
@@ -256,7 +256,6 @@
           "subdir": "jsonnet/kube-thanos"
         }
       },
-      
       "version": "ac261330bb819523d2caba81b4e82add166436c7",
       "sum": "sN9PqW93Kh+jyf5kvRKQgotY3xbRIU/h22TcNO2KTag=",
       "name": "upstream-kube-thanos"

--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -61,6 +61,7 @@ local operatorObs = obs {
     } + if std.objectHas(cr.spec.thanos, 'receiveController') then cr.spec.thanos.receiveController else {},
 
     receivers+:: {
+      logLevel: if std.objectHas(cr.spec.thanos, 'receivers') && std.objectHas(cr.spec.thanos.receivers, 'logLevel') then cr.spec.thanos.receivers.logLevel else 'info',
       securityContext: if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else obs.thanos.receivers.config.securityContext,
     } + if std.objectHas(cr.spec.thanos, 'receivers') then cr.spec.thanos.receivers else {},
 

--- a/jsonnet/vendor/github.com/stolostron/observatorium-deployment/configuration/components/thanos.libsonnet
+++ b/jsonnet/vendor/github.com/stolostron/observatorium-deployment/configuration/components/thanos.libsonnet
@@ -88,6 +88,23 @@ local defaults = {
     replicationFactor: 1,
     retention: '4d',
     storage: '50Gi',
+    logLevel: 'info',
+    enableLocalEndpoint: true,
+    logFormat: 'logfmt',
+    labels: [
+      'replica="$(NAME)"',
+      'receive="true"',
+    ],
+    ports: {
+      grpc: 10901,
+      http: 10902,
+      'remote-write': 19291,
+    },
+    storeLimits: {},
+    tracing: {},
+    receiveLimitsConfigFile: {},
+    tenantLabelName: null,
+    tenantHeader: null,
     serviceMonitor: false,
     volumeClaimTemplate: {
       spec: {
@@ -212,7 +229,6 @@ function(params) {
     replicaLabels: thanos.config.replicaLabels,
     objectStorageConfig: thanos.config.objectStorageConfig,
     hashringConfigMapName: '%s-generated' % thanos.receiveController.configmap.metadata.name,
-    logLevel: 'info',
   }),
 
   rule:: t.rule(thanos.config.rule {

--- a/jsonnet/vendor/github.com/stolostron/observatorium/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/vendor/github.com/stolostron/observatorium/jsonnet/lib/observatorium-api.libsonnet
@@ -26,6 +26,7 @@ local defaults = {
   rateLimiter: {},
   internal: {},
   extraVolumeMounts: [],
+  securityContext: {},
 
   commonLabels:: {
     'app.kubernetes.io/name': 'observatorium-api',
@@ -108,6 +109,7 @@ function(params) {
               name: 'observatorium-api',
               image: api.config.image,
               imagePullPolicy: api.config.imagePullPolicy,
+              securityContext: api.config.securityContext,
               args: [
                 '--web.listen=0.0.0.0:%s' % api.config.ports.public,
                 '--web.internal.listen=0.0.0.0:%s' % api.config.ports.internal,
@@ -158,6 +160,12 @@ function(params) {
                     if std.objectHas(api.config.tls, 'serverName') then
                       [
                         '--tls.healthchecks.server-name=' + api.config.tls.serverName,
+                      ]
+                    else []
+                  ) + (
+                    if std.objectHas(api.config.tls, 'cipherSuites') then
+                      [
+                        '--tls.cipher-suites=' + api.config.tls.cipherSuites,
                       ]
                     else []
                   )
@@ -297,19 +305,20 @@ function(params) {
                         readOnly: true,
                       }
                       for name in api.config.additionalWriteEndpoints.mountSecrets
-                    ] else [])
-                   else []
-                 ) + (
-                   if std.length(api.config.extraVolumeMounts) > 0 then [
-                     {
-                       name: volumeMount.name,
-                       mountPath: volumeMount.mountPath,
-                       subPath: volumeMount.key,
-                       readOnly: true,
-                     }
-                     for volumeMount in api.config.extraVolumeMounts
-                   ] else []
-                 ),
+                    ] else []
+                  )
+                  else []
+                ) + (
+                  if std.length(api.config.extraVolumeMounts) > 0 then [
+                    {
+                      name: mount.name,
+                      mountPath: mount.mountPath,
+                      subPath: mount.key,
+                      readOnly: true,
+                    }
+                    for mount in api.config.extraVolumeMounts
+                  ] else []
+                ),
             },
           ],
           volumes:
@@ -391,16 +400,14 @@ function(params) {
               ] else [])
              else []) +
             (if std.length(api.config.extraVolumeMounts) > 0 then [
-               { name: volumeMount.name } +
-               (
-                 if volumeMount.type == 'configMap' then {
-                   configMap: { name: volumeMount.name },
-                 }
-                 else {
-                   secret: { secretName: volumeMount.name },
-                 }
-               )
-               for volumeMount in api.config.extraVolumeMounts
+               if mount.type == 'configMap' then {
+                 name: mount.name,
+                 configMap: { name: mount.name },
+               } else {
+                 name: mount.name,
+                 secret: { secretName: mount.name },
+               }
+               for mount in api.config.extraVolumeMounts
              ] else []),
         },
       },

--- a/manifests/crds/core.observatorium.io_observatoria.yaml
+++ b/manifests/crds/core.observatorium.io_observatoria.yaml
@@ -8250,6 +8250,10 @@ spec:
                           - name
                           type: object
                         type: array
+                      logLevel:
+                        description: LogLevel sets the log verbosity for the Thanos
+                          Receive component.
+                        type: string
                       replicas:
                         description: Number of Receiver replicas.
                         format: int32


### PR DESCRIPTION
Summary:

Fixes [ACM-35791](https://redhat.atlassian.net/browse/ACM-35791)

Problem:

When working on [ACM-34601](https://redhat.atlassian.net/browse/ACM-34601), I noticed that when the Observatorium Operator had arguments passed to it that overrode the default arguments for Thanos Receive, it would append these arguments to the args list. This caused Thanos Recieve pods to not start, as Thanos does not support having multiple instances of the same argument. 

Root Cause:
The root cause is the Observatorium Operator appending all additional arguments to the args list rather than overriding when needed.

Fix:

Add function to merge/override one array of arguments into another and use this function in Thanos Recieve args generation

Files Changed:

Modified:
`obs-operator.jsonnet`

Test Plan:
Same fix achieves desired behavior in Thanos Compact Args, will be testing end to end to confirm

[ACM-35791]: https://redhat.atlassian.net/browse/ACM-35791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ACM-34601]: https://redhat.atlassian.net/browse/ACM-34601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ