### PR TITLE
fix: remove runAsGroup from default security contexts to fix containerd compatibility

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -12,7 +12,6 @@ local tlsProfileConfig = (
 );
 
 local basePodSecurityContext = {
-  runAsGroup: 65532,
   runAsNonRoot: true,
   seccompProfile: { type: 'RuntimeDefault' },
 };
@@ -20,7 +19,6 @@ local basePodSecurityContext = {
 local crSecurityContext = basePodSecurityContext + (if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else {});
 
 local baseContainerSecurityContext = {
-  runAsGroup: 65532,
   runAsNonRoot: true,
   allowPrivilegeEscalation: false,
   readOnlyRootFilesystem: true,


### PR DESCRIPTION
## Summary

- Remove `runAsGroup: 65532` from `basePodSecurityContext` and `baseContainerSecurityContext` in `jsonnet/obs-operator.jsonnet`
- Fixes containerd v1.7.13 (KinD v0.22.0) sandbox creation failure blocking all e2e-kind CI tests

## Problem

PR #449 added `runAsGroup: 65532` to default security contexts without a corresponding `runAsUser`. containerd v1.7.13 rejects this combination:

```
FailedCreatePodSandBox: failed to generate sandbox container spec options:
  failed to generate user string: user group "65532" is specified without user
```

**All Thanos pods** (`compact`, `query`, `query-frontend`, `receive`, `rule`, `store`, `memcached`) are stuck in `ContainerCreating`, blocking every e2e-kind CI run on `stolostron/multicluster-observability-operator`.

### Evidence from CI (KinD cluster)

**All Thanos pods stuck in ContainerCreating**
<img width="1160" height="283" alt="Screenshot 2026-07-30 at 4 27 33 PM" src="https://github.com/user-attachments/assets/82d1537d-9975-419f-8a8e-97514eb73438" />


**FailedCreatePodSandBox events & security context showing runAsGroup without runAsUser**
<img width="1546" height="318" alt="Screenshot 2026-07-30 at 4 29 25 PM" src="https://github.com/user-attachments/assets/c4430b4c-fbac-4016-9eba-b64c9e5f84eb" />

## Why NOT add `runAsUser: 65534`

The initial instinct is to add `runAsUser: 65534` (matching [kube-thanos upstream](https://github.com/stolostron/kube-thanos/commit/48639958ccd4fa81fbb261ce4f9e790d69c71e2e)). However, this breaks OpenShift:

- OpenShift's `restricted-v2` SCC uses `MustRunAsRange` for `runAsUser`
- `MustRunAsRange` **validates** (rejects) when `runAsUser` IS explicitly set outside the namespace range
- It only **defaults** (mutates) when `runAsUser` is NOT set
- UID `65534` falls outside namespace-allocated ranges
- OpenShift's own [cluster-monitoring-operator Thanos querier](https://github.com/openshift/cluster-monitoring-operator) deliberately omits `runAsUser`

## Fix: Remove `runAsGroup` from defaults

Remove `runAsGroup: 65532` from both security context blocks. This works on all platforms:

| Platform | Behavior |
|----------|----------|
| **KinD/containerd** | No `runAsGroup` → containerd doesn't require `runAsUser` → sandbox succeeds |
| **OpenShift** | `runAsNonRoot: true` compatible with `restricted-v2`; SCC assigns both UID and GID from namespace range |
| **Kubernetes** | Container runtime assigns default GID; runAsNonRoot: true ensures non-root UID |

### Security posture preserved

All other hardening remains intact:
- `runAsNonRoot: true` — prevents root execution
- `seccompProfile: { type: 'RuntimeDefault' }` — syscall filtering
- `allowPrivilegeEscalation: false` — no privilege escalation
- `capabilities: { drop: ['ALL'] }` — no Linux capabilities
- `readOnlyRootFilesystem: true` — immutable container filesystem
- Meets Kubernetes Pod Security Standards `restricted` level

### CR override preserved

The jsonnet merge mechanism is unaffected:
```jsonnet
local crSecurityContext = basePodSecurityContext +
  (if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else {});
```
Deployments can still add `runAsGroup` (and/or `runAsUser`) via `cr.spec.securityContext` if needed.

## References
- containerd source: [`generateUserString`](https://github.com/containerd/containerd/blob/v1.7.13/pkg/cri/server/container_create_linux.go) rejects group-without-user
- Upstream reference: [kube-thanos commit 4863995](https://github.com/stolostron/kube-thanos/commit/48639958) sets both `runAsUser: 65534` AND `runAsGroup: 65532`
- Affected PRs: All e2e-kind on stolostron/multicluster-observability-operator (e.g., [#2567](https://github.com/stolostron/multicluster-observability-operator/pull/2567))
