### PR TITLE
fix: remove runAsNonRoot and seccompProfile from pod-level security context

### DIFF
--- a/jsonnet/obs-operator.jsonnet
+++ b/jsonnet/obs-operator.jsonnet
@@ -11,10 +11,7 @@ local tlsProfileConfig = (
   if std.objectHas(tlsProfile, 'minVersion') then { tlsMinVersion: tlsProfile.minVersion } else {}
 );
 
-local basePodSecurityContext = {
-  runAsNonRoot: true,
-  seccompProfile: { type: 'RuntimeDefault' },
-};
+local basePodSecurityContext = {};
 
 local crSecurityContext = basePodSecurityContext + (if std.objectHas(cr.spec, 'securityContext') then cr.spec.securityContext else {});
 


### PR DESCRIPTION
## Problem

PR #449 added `runAsNonRoot: true` and `seccompProfile: RuntimeDefault` to `basePodSecurityContext` in `obs-operator.jsonnet`. Pod-level security context inherits to **all** containers in the pod, including third-party sidecars.

Three third-party images use non-numeric USER strings:
- `memcached:1.6.3-alpine` — `USER memcache` (UID 11211)
- `memcached-exporter:v0.9.0` — `USER nobody` (UID 65534)
- `configmap-reloader:4.8.0` — `USER nobody` (UID 65534)

Kubelet's `verifyRunAsNonRoot` uses `strconv.ParseInt` to parse the image USER field. Non-numeric strings fail → `CreateContainerConfigError`.

On OpenShift this is masked by SCC `MustRunAsRange` injecting a numeric UID at admission time. On KinD (used by e2e-kind CI) there is no SCC → pods fail.

**Affected pods:**
- `observability-thanos-query-frontend-memcached` (memcached + exporter)
- `observability-thanos-store-memcached` (memcached + exporter)
- `observability-thanos-rule` (configmap-reloader sidecar)
- `observability-thanos-store-shard-*` (cascade — CrashLoopBackOff due to memcached DNS failure)

## Fix

Empty `basePodSecurityContext` — remove both `runAsNonRoot` and `seccompProfile` from pod-level context.

- **`runAsNonRoot`**: Breaks third-party images with non-numeric USER strings on KinD. Container-level `baseContainerSecurityContext` retains `runAsNonRoot: true` for thanos containers via `securityContextContainer`.
- **`seccompProfile`**: On OpenShift, the `restricted-v2` SCC already manages seccomp defaults. Hardcoding `RuntimeDefault` would prevent inheriting future OCP profile changes. Container-level `baseContainerSecurityContext` retains it for thanos containers.

## Why this is safe

| Layer | Before | After |
|-------|--------|-------|
| Pod-level `runAsNonRoot` | `true` (breaks third-party images on KinD) | absent |
| Pod-level `seccompProfile` | `RuntimeDefault` (overrides OCP defaults) | absent (OCP SCC manages it) |
| Container-level (thanos) | Full hardening via `baseContainerSecurityContext` | Unchanged |
| OpenShift SCC | Injects numeric UID + seccomp independently | Unchanged |

- 5 of 7 thanos containers retain full hardening at container level (query, query-frontend, store, rule, receive-router)
- 2 thanos containers (compact, receive) lose pod-level settings due to a pre-existing kube-thanos template gap — tracked separately
- Matches the pattern used by alertmanager in the same cluster (`securityContext: {}`)

## Validated

- Built and deployed patched observatorium-operator image to a KinD CI cluster
- All previously failing pods (memcached, exporter, configmap-reloader, store shards) now Running
- No new errors in operator logs

## Related

- [PR #449](https://github.com/stolostron/observatorium-operator/pull/449) — added security contexts (introduced this issue)
- [PR #450](https://github.com/stolostron/observatorium-operator/pull/450) — removed `runAsGroup` (Bug 1 fix)
- [thanos PR #376](https://github.com/stolostron/thanos/pull/376) — added `USER 1001` to Dockerfile.prow (Bug 2 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)